### PR TITLE
Make path_completer compatible with windows

### DIFF
--- a/pypsi/completers.py
+++ b/pypsi/completers.py
@@ -41,7 +41,7 @@ def path_completer(shell, args, prefix):
                 root = '.' + os.path.sep + root
         else:
             root = '.' + os.path.sep
-        root = drive + root
+        root = os.path.join(drive, root)
     else:
         root = '.' + os.path.sep
 


### PR DESCRIPTION
Use normcase to use case insensitive paths on Windows
Use splitdrive to recognize windows drive letters if present
