### PR TITLE
import pypsi.os.unix.* on Darwin too

### DIFF
--- a/pypsi/os/__init__.py
+++ b/pypsi/os/__init__.py
@@ -22,7 +22,7 @@ import sys
 
 if sys.platform == 'win32':
     from pypsi.os.win32 import *
-elif sys.platform == 'cygwin' or sys.platform.startswith('linux'):
+elif sys.platform in ['cygwin', 'darwin'] or sys.platform.startswith('linux'):
     from pypsi.os.unix import *
 
 


### PR DESCRIPTION
Without some check for Darwin in `pypsi.os`, Pypsi is unusable on Mac OS, with this traceback:

	Traceback (most recent call last):
	  File "/usr/local/bin/inv", line 11, in <module>
		sys.exit(program.run())
	  File "/usr/local/lib/python3.4/site-packages/invoke/program.py", line 269, in run
		self._parse(argv)
	  File "/usr/local/lib/python3.4/site-packages/invoke/program.py", line 323, in _parse
		self.load_collection()
	  File "/usr/local/lib/python3.4/site-packages/invoke/program.py", line 471, in load_collection
		coll = loader.load(coll_name) if coll_name else loader.load()
	  File "/usr/local/lib/python3.4/site-packages/invoke/loader.py", line 53, in load
		module = imp.load_module(name, fd, path, desc)
	  File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/imp.py", line 235, in load_module
		return load_source(name, filename, file)
	  File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/imp.py", line 171, in load_source
		module = methods.load()
	  File "<frozen importlib._bootstrap>", line 1220, in load
	  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
	  File "<frozen importlib._bootstrap>", line 1129, in _exec
	  File "<frozen importlib._bootstrap>", line 1471, in exec_module
	  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
	  File "/Users/cfm/work/trinity/v3/tasks.py", line 60, in <module>
		from scripts.profile_config import ConfigShell
	  File "/Users/cfm/work/trinity/v3/scripts/profile_config.py", line 8, in <module>
		from pypsi.shell import Shell
	  File "/usr/local/lib/python3.4/site-packages/pypsi/shell.py", line 22, in <module>
		from pypsi.completers import path_completer
	  File "/usr/local/lib/python3.4/site-packages/pypsi/completers.py", line 22, in <module>
		from pypsi.os import path_completer  # noqa
	ImportError: cannot import name 'path_completer'

If I understand `pypsi.os`'s `__init__.py` correctly, it's a very minor fix.