### PR TITLE
Fix command tab completion and completing path '/'

### DIFF
--- a/pypsi/commands/include.py
+++ b/pypsi/commands/include.py
@@ -52,7 +52,7 @@ class IncludeCommand(Command):
         self.stack = []
 
     def complete(self, shell, args, prefix):
-        return path_completer(args[-1])
+        return path_completer(args[-1], prefix=prefix)
 
     def run(self, shell, args):
         try:

--- a/pypsi/commands/tail.py
+++ b/pypsi/commands/tail.py
@@ -82,7 +82,7 @@ class TailCommand(Command):
         return 0
 
     def complete_path(self, shell, args, prefix):  # pylint: disable=unused-argument
-        return path_completer(args[-1])
+        return path_completer(args[-1], prefix=prefix)
 
     def complete(self, shell, args, prefix):
         # The command_completer function takes in the parser, automatically

--- a/pypsi/completers.py
+++ b/pypsi/completers.py
@@ -141,7 +141,7 @@ def path_completer(token, prefix=''):
     if not token:
         cwd = '.' + os.path.sep
         filename_prefix = ''
-    elif token[-1] == os.path.sep:
+    elif len(token) > 1 and token[-1] == os.path.sep:
         cwd = os.path.expanduser(token[:-1])
         filename_prefix = ''
     else:

--- a/pypsi/completers.py
+++ b/pypsi/completers.py
@@ -142,7 +142,7 @@ def path_completer(token, prefix=''):
         cwd = '.' + os.path.sep
         filename_prefix = ''
     elif len(token) > 1 and token[-1] == os.path.sep:
-        cwd = os.path.expanduser(token[:-1])
+         cwd = os.path.expanduser(token[:-1] or os.path.sep)
         filename_prefix = ''
     else:
         filename_prefix = os.path.basename(token)

--- a/pypsi/completers.py
+++ b/pypsi/completers.py
@@ -142,7 +142,7 @@ def path_completer(token, prefix=''):
         cwd = '.' + os.path.sep
         filename_prefix = ''
     elif len(token) > 1 and token[-1] == os.path.sep:
-         cwd = os.path.expanduser(token[:-1] or os.path.sep)
+        cwd = os.path.expanduser(token[:-1] or os.path.sep)
         filename_prefix = ''
     else:
         filename_prefix = os.path.basename(token)

--- a/pypsi/plugins/history.py
+++ b/pypsi/plugins/history.py
@@ -49,7 +49,7 @@ class HistoryCommand(Command):
 
         if len(args) == 2:
             if args[0] == 'save' or args[0] == 'load':
-                return path_completer(args[-1])
+                return path_completer(args[-1], prefix=prefix)
         return []
 
     def setup_parser(self, brief):

--- a/test/test_completers/test_path_completer.py
+++ b/test/test_completers/test_path_completer.py
@@ -65,6 +65,12 @@ class TestPathCompleter:
         self.exists_mock.return_value = True
         assert path_completer('a ', '') == ['file\0', 'dir' + os.path.sep]
 
+    def test_root_no_prefix(self):
+        self.listdir_mock.return_value = ['bin', 'sys']
+        self.isdir_mock.side_effect = [True, True, True]
+        self.exists_mock.return_value = True
+        assert path_completer('/', '') == ['bin' + os.path.sep, 'sys' + os.path.sep]
+
     def test_path_sep_token(self):
         self.listdir_mock.return_value = ['file1', 'dir1']
         self.isdir_mock.side_effect = [True, False, True]


### PR DESCRIPTION
Fixes command path completion for PyPsi Commands and completing the path `/` on Linux.

closes #42 
closes #43