### PR TITLE
Fix unhandled exception in `find_bins_in_path`

### DIFF
--- a/pypsi/os/unix.py
+++ b/pypsi/os/unix.py
@@ -60,14 +60,18 @@ def make_ansi_stream(stream, **kwargs):
 
 def find_bins_in_path():
     bins = set()
-    paths = [x for x in os.environ['PATH'].split(':') if x.strip()]
+    paths = [x for x in os.environ.get('PATH', '').split(':') if x.strip()]
     paths.append('./')
     for path in paths:
         path = path or './'
-        for entry in os.listdir(path):
-            p = os.path.join(path, entry)
-            if os.path.isfile(p) and os.access(p, os.X_OK):
-                bins.add(entry)
+        try:
+            for entry in os.listdir(path):
+                p = os.path.join(path, entry)
+                if os.path.isfile(p) and os.access(p, os.X_OK):
+                    bins.add(entry)
+        except:
+            # bare except here because if this fails, tab completion can be entirely broken
+            pass
     return bins
 
 

--- a/test/test_completers/test_find_bins_in_path.py
+++ b/test/test_completers/test_find_bins_in_path.py
@@ -1,5 +1,4 @@
 from unittest.mock import patch
-from typing import List
 
 from pypsi.os import find_bins_in_path
 
@@ -7,11 +6,6 @@ from pypsi.os import find_bins_in_path
 # Example Data
 DIR1 = ['cat', 'grep', 'find', 'sort']
 DIR2 = ['awk', 'sed', 'ed', 'tr']
-
-
-def mock_listdir(path: str) -> List[str]:
-    print(path)
-    return [path]
 
 
 class TestPathCompleter:

--- a/test/test_completers/test_find_bins_in_path.py
+++ b/test/test_completers/test_find_bins_in_path.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+import os
+from pypsi.os import find_bins_in_path
+
+
+class TestPathCompleter:
+
+    def setup(self):
+        base_path = os.path.dirname(os.path.abspath(__file__))
+        self.actual_path = os.environ.get('PATH', '')
+
+        self.environ_patch = patch('os.environ')
+        self.environ_mock = self.environ_patch.start()
+
+    def teardown(self):
+        self.environ_mock.stop()
+
+    def test_path_unset(self):
+        # An empty or missing PATH will result in checking `./`, which checks the current repo
+        self.environ_mock.return_value = f"./"
+        baseline_ans = find_bins_in_path()
+
+        self.environ_mock.return_value = None
+        ans = find_bins_in_path()
+        # if path is unset for some reason,
+        # we should still return zero results
+        assert ans == baseline_ans
+
+    def test_path_set_empty(self):
+        # An empty or missing PATH will result in checking `./`, which checks the current repo
+        self.environ_mock.return_value = f"./"
+        baseline_ans = find_bins_in_path()
+
+        self.environ_mock.return_value = ""
+        ans = find_bins_in_path()
+        # a path of nothing should still return an empty set
+        assert ans == baseline_ans
+
+    def test_path_contains_nonexistent_path(self):
+        self.environ_mock.return_value = f"{self.actual_path}"
+        baseline_ans = find_bins_in_path()
+
+        self.environ_mock.return_value = f"{self.actual_path}:nonexistent"
+        ans = find_bins_in_path()
+
+        # a path variable with a non-existent directory should still return some bins
+        # this isn't a great test, because baseline_ans could still return an empty set
+        assert ans == baseline_ans


### PR DESCRIPTION
Closes #51 

Fixes an unhandled exception in helper function `find_bins_in_path`. Covers 3 main cases:

- A path in PATH is not found (`FileNotFoundError`)
- A path in PATH is not readable (`PermssionError`)
- Path is `unset` for some reason